### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ You are ready to go!
 - Run `make module`
 - You will see a directory named `NumSwiftModule`
     + There are three files in that directory: `NumSwift.swiftmodule`, `NumSwift.swiftdoc` and `libNumSwift.dylib`
-- Include files generated in `NumSwiftModule` in you XCode Project.
-    + If you hate XCode just like me, you can use `swiftc` instead with flags `-I` and `-L`
+- Include files generated in `NumSwiftModule` in you Xcode Project.
+    + If you hate Xcode just like me, you can use `swiftc` instead with flags `-I` and `-L`
     + ex: Suppose you have a `main.swift` and import `NumSwift` in it, you can run `xcrun -sdk macosx swiftc -I /path/to/NumSwiftModule -L /path/to/NumSwiftModule -lNumSwift -o main`. 
 
 ## Importable Framework


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
